### PR TITLE
Dockerfile for lampe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:15.10
+
+RUN apt-get clean && \
+    apt-get update && \
+    apt-get -y install \
+               libsoup2.4-dev \
+               libgtk-3-dev \
+               libjson-glib-dev \
+               valac \
+               make \
+               gcc \
+               apt-utils \
+               libgl1-mesa-glx \
+               libglapi-mesa \
+               git
+
+RUN git clone https://github.com/poinck/lampe.git && \
+    cd lampe && \
+    make && \
+    make install
+
+CMD /lampe/lampe-gtk


### PR DESCRIPTION
Using that Dockerfile, one can build & run lampe (AND lampe-gtk) without having ubuntu 15.10 and vala/gtk installed.

Suggested paramters for X11 socket connect (application shown like a native X11-app):
`docker run -it -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group -v ${HOME}:${HOME} -u $(id -u) -w ${HOME} YOUR_IMAGE_ID`